### PR TITLE
Actualización de la función: "filling_blanks_santiago_submit"

### DIFF
--- a/public_html/js/plantilla/actividades_result.js
+++ b/public_html/js/plantilla/actividades_result.js
@@ -767,7 +767,7 @@ function filling_blanks_santiago_submit(evt) {
 
     retroalimentacion(strRetro);
     save_extra_data(objEvt, evt);
-    upload_interaction(evt.json.preguntas, evt.answer, evt.position_which_is_right, evt.interactionType, evt);
+    upload_interaction(evt.json.pregunta, evt.answer, evt.results, evt.interactionType, evt);
     send_evt_to(evt.identify, objEvt, evt.results);
 }
 


### PR DESCRIPTION
Se modifica la función filling_blanks_santiago_submit puesto que generaba problemas en los resultados dentro de la plantilla, ahora se envía el objeto como debe ser.
